### PR TITLE
Implement on download event

### DIFF
--- a/projects/ngx-extended-pdf-viewer/src/lib/ngx-extended-pdf-viewer.component.ts
+++ b/projects/ngx-extended-pdf-viewer/src/lib/ngx-extended-pdf-viewer.component.ts
@@ -13,6 +13,7 @@ import {
 } from '@angular/core';
 import { PagesLoadedEvent } from './pages-loaded-event';
 import { PageRenderedEvent } from './page-rendered-event';
+import { PdfDownloadedEvent } from './pdf-downloaded-event';
 import { defaultOptions } from './default-options';
 import {
   resizeUpTo900px,
@@ -218,6 +219,9 @@ export class NgxExtendedPdfViewerComponent implements OnInit, OnChanges, OnDestr
 
   @Output()
   public pageRendered = new EventEmitter<PageRenderedEvent>();
+
+  @Output()
+  public pdfDownloaded = new EventEmitter<PdfDownloadedEvent>();
 
   /** Legal values: undefined, 'auto', 'page-actual', 'page_fit', 'page-width', or '50' (or any other percentage) */
   @Input()
@@ -533,6 +537,9 @@ export class NgxExtendedPdfViewerComponent implements OnInit, OnChanges, OnDestr
     });
     (<any>window).PDFViewerApplication.eventBus.on('pagerendered', (x: PageRenderedEvent) => {
       this.pageRendered.emit(x);
+    });
+    (<any>window).PDFViewerApplication.eventBus.on('download', (x: PdfDownloadedEvent) => {
+      this.pdfDownloaded.emit(x);
     });
     this.checkHeight();
     // open a file in the viewer

--- a/projects/ngx-extended-pdf-viewer/src/lib/pdf-downloaded-event.ts
+++ b/projects/ngx-extended-pdf-viewer/src/lib/pdf-downloaded-event.ts
@@ -1,0 +1,3 @@
+export interface PdfDownloadedEvent {
+  source: any; // Toolbar
+}

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -114,6 +114,7 @@
         [(spread)]="spread"
         [language]="language"
         (pageRendered)="onPageRendered($event)"
+        (pdfDownloaded)="onDownload($event)"
         [(zoom)]="zoom"
         [showHandToolButton]="true"
       >

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -2,8 +2,8 @@ import { Component } from '@angular/core';
 import { PagesLoadedEvent } from 'projects/ngx-extended-pdf-viewer/src/lib/pages-loaded-event';
 import { pdfBase64 } from './pdfBase64';
 import { PageRenderedEvent } from '../../projects/ngx-extended-pdf-viewer/src/lib/page-rendered-event';
+import { PdfDownloadedEvent } from '../../projects/ngx-extended-pdf-viewer/src/lib/pdf-downloaded-event';
 import { NgxExtendedPdfViewerService } from '../../projects/ngx-extended-pdf-viewer/src/lib/ngx-extended-pdf-viewer.service';
-import {PdfDownloadedEvent} from '../../projects/ngx-extended-pdf-viewer/src/lib/pdf-downloaded-event';
 
 @Component({
   selector: 'app-root',

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -3,6 +3,7 @@ import { PagesLoadedEvent } from 'projects/ngx-extended-pdf-viewer/src/lib/pages
 import { pdfBase64 } from './pdfBase64';
 import { PageRenderedEvent } from '../../projects/ngx-extended-pdf-viewer/src/lib/page-rendered-event';
 import { NgxExtendedPdfViewerService } from '../../projects/ngx-extended-pdf-viewer/src/lib/ngx-extended-pdf-viewer.service';
+import {PdfDownloadedEvent} from '../../projects/ngx-extended-pdf-viewer/src/lib/pdf-downloaded-event';
 
 @Component({
   selector: 'app-root',
@@ -188,6 +189,10 @@ export class AppComponent {
   }
 
   public onPageRendered(event: PageRenderedEvent) {
+    console.log(event);
+  }
+
+  public onDownload(event: PdfDownloadedEvent) {
     console.log(event);
   }
 


### PR DESCRIPTION
Hijacks the event fired by the following lines in viewer.js (line 13263 - 13267).

```
      items.download.addEventListener('click', function () {
        eventBus.dispatch('download', {
          source: self
        });
      });
```

Let me know if theres any issues :)