### PR TITLE
  * Added more robust access to current page number

### DIFF
--- a/projects/ngx-extended-pdf-viewer/src/lib/ngx-extended-pdf-viewer.component.ts
+++ b/projects/ngx-extended-pdf-viewer/src/lib/ngx-extended-pdf-viewer.component.ts
@@ -524,8 +524,7 @@ export class NgxExtendedPdfViewerComponent implements OnInit, OnChanges, OnDestr
 
   public onPageChange(): void {
     setTimeout(() => {
-      const inputField = document.getElementById('pageNumber') as HTMLInputElement;
-      let page: number | undefined = Number(inputField.value);
+      let page: number | undefined = Number((<any>window).PDFViewerApplication.page);
       if (isNaN(page)) {
         page = undefined;
       }


### PR DESCRIPTION
ngx-extended-pdf-viewer page does emit undefinied when pdf file does use non numeric page numbers e.g. http://www.connectedthebook.com/pdf/excerpt.pdf. 

Not sure if this fix could cause some trouble elsewhere. In my case it's doing the job.