### PR TITLE
Add option for removing page borders in the viewer

### DIFF
--- a/projects/ngx-extended-pdf-viewer/src/assets/viewer.js
+++ b/projects/ngx-extended-pdf-viewer/src/assets/viewer.js
@@ -478,6 +478,10 @@ let PDFViewerApplication = {
       _app_options.AppOptions.set('useOnlyCssZoom', hashParams['useonlycsszoom'] === 'true');
     }
 
+    if ('removepageborders' in hashParams) {
+      _app_options.AppOptions.set('removePageBorders', hashParams['removepageborders'] === 'true');
+    }
+
     if ('verbosity' in hashParams) {
       _app_options.AppOptions.set('verbosity', hashParams['verbosity'] | 0);
     }
@@ -560,6 +564,7 @@ let PDFViewerApplication = {
       l10n: this.l10n,
       textLayerMode: _app_options.AppOptions.get('textLayerMode'),
       imageResourcesPath: _app_options.AppOptions.get('imageResourcesPath'),
+      removePageBorders: _app_options.AppOptions.get('removePageBorders'),
       renderInteractiveForms: _app_options.AppOptions.get('renderInteractiveForms'),
       enablePrintAutoRotate: _app_options.AppOptions.get('enablePrintAutoRotate'),
       useOnlyCssZoom: _app_options.AppOptions.get('useOnlyCssZoom'),
@@ -3325,6 +3330,10 @@ const defaultOptions = {
     value: false,
     kind: OptionKind.VIEWER + OptionKind.PREFERENCE
   },
+  removePageBorders: {
+    value: false,
+    kind: OptionKind.VIEWER + OptionKind.PREFERENCE
+  },
   renderer: {
     value: 'canvas',
     kind: OptionKind.VIEWER + OptionKind.PREFERENCE
@@ -5501,7 +5510,7 @@ class PDFFindController {
               pageContent = window.deburr(pageContent); // #177
               query = window.deburr(query); // #177
             } // #177
-  
+
     const matches = [];
     const queryLen = query.length;
     let matchIdx = -queryLen;
@@ -5528,7 +5537,7 @@ class PDFFindController {
               pageContent = window.deburr(pageContent); // #177
               query = window.deburr(query); // #177
             } // #177
-  
+
     const matchesWithLength = [];
     const queryArray = query.match(/\S+/g);
 
@@ -8806,6 +8815,7 @@ class BaseViewer {
           textLayerMode: this.textLayerMode,
           annotationLayerFactory: this,
           imageResourcesPath: this.imageResourcesPath,
+          removePageBorders: this.removePageBorders,
           renderInteractiveForms: this.renderInteractiveForms,
           renderer: this.renderer,
           enableWebGL: this.enableWebGL,
@@ -11454,6 +11464,7 @@ function getDefaultPreferences() {
       "externalLinkTarget": 0,
       "historyUpdateUrl": false,
       "pdfBugEnabled": false,
+      "removePageBorders": false,
       "renderer": "canvas",
       "renderInteractiveForms": false,
       "sidebarViewOnLoad": -1,

--- a/projects/ngx-extended-pdf-viewer/src/lib/ngx-extended-pdf-viewer.component.ts
+++ b/projects/ngx-extended-pdf-viewer/src/lib/ngx-extended-pdf-viewer.component.ts
@@ -283,6 +283,8 @@ export class NgxExtendedPdfViewerComponent implements OnInit, OnChanges, OnDestr
   public showSpreadButton = true;
   @Input()
   public showPropertiesButton = true;
+  @Input()
+  public removePageBorders = false;
 
   @Input()
   public spread: 'off' | 'even' | 'odd';
@@ -711,6 +713,9 @@ export class NgxExtendedPdfViewerComponent implements OnInit, OnChanges, OnDestr
     }
     if (this.printResolution) {
       options.set('printResolution', this.printResolution);
+    }
+    if (this.removePageBorders) {
+      options.set('removePageBorders', this.removePageBorders);
     }
   }
 

--- a/projects/ngx-extended-pdf-viewer/src/lib/options/default-options.ts
+++ b/projects/ngx-extended-pdf-viewer/src/lib/options/default-options.ts
@@ -15,6 +15,7 @@ export const defaultOptions = {
   imageResourcesPath: './images/',
   maxCanvasPixels: 16777216,
   pdfBugEnabled: false,
+  removePageBorders: false,
   renderer: 'canvas',
   renderInteractiveForms: false,
   sidebarViewOnLoad: -1,


### PR DESCRIPTION
Hi,

First of all, thanks for the wonderful package. We moved to this after using ng2-pdf-viewer, since this solved a lot of our problems with some security issues.

However, ng2-pdf-viewer provided an option to remove page borders, which was sorely missed.

This is my attempt to add it to NGX Extended PDF Viewer.

I mostly looked at how other options were implemented and duplicated them. Kindly review and let me know whether any other changes are required, and whether I should add an additional example with page borders removed in the demo application.

P.S. It'll be great if this can be pushed into the 2.0.0 release.

Cheers.