### PR TITLE
docs(README): change dist/ to node_modules/

### DIFF
--- a/projects/ngx-extended-pdf-viewer/README.md
+++ b/projects/ngx-extended-pdf-viewer/README.md
@@ -61,7 +61,7 @@ The detailed instructions for JHipster and Angular 2, 4, and 5 are available [on
       "src/assets",
       {
         "glob": "**/*",
-        "input": "dist/ngx-extended-pdf-viewer/assets/",
+        "input": "node_modules/ngx-extended-pdf-viewer/assets/",
         "output": "/assets/"
       }
     ],


### PR DESCRIPTION
In common case, node_modules folder would be better than dist folder. :) 

