### PR TITLE
Missing #outerContainer selector in dynamic CSS

### DIFF
--- a/projects/ngx-extended-pdf-viewer/src/lib/dynamic-css/dynamic-css.component.ts
+++ b/projects/ngx-extended-pdf-viewer/src/lib/dynamic-css/dynamic-css.component.ts
@@ -60,7 +60,7 @@ export class DynamicCssComponent implements OnInit, OnChanges, OnDestroy {
 }
 
 @media all and (max-width: ${this.lg}px) {
-  #outerContainer .toolbarButtonSpacer {
+  .toolbarButtonSpacer {
     width: 15px;
   }
 
@@ -73,7 +73,7 @@ export class DynamicCssComponent implements OnInit, OnChanges, OnDestroy {
 }
 
 @media all and (max-width: ${this.md}px) {
-  #outerContainer .toolbarButtonSpacer {
+  .toolbarButtonSpacer {
     display: none;
   }
   #outerContainer .hiddenMediumView {
@@ -92,7 +92,7 @@ export class DynamicCssComponent implements OnInit, OnChanges, OnDestroy {
   #outerContainer .visibleSmallView {
     display: inherit;
   }
-  #outerContainer .toolbarButtonSpacer {
+  .toolbarButtonSpacer {
     width: 0;
   }
   html[dir='ltr'] .findbar {

--- a/projects/ngx-extended-pdf-viewer/src/lib/dynamic-css/dynamic-css.component.ts
+++ b/projects/ngx-extended-pdf-viewer/src/lib/dynamic-css/dynamic-css.component.ts
@@ -1,5 +1,5 @@
-import { Component, OnInit, Renderer2, Inject, OnChanges, Input, OnDestroy } from '@angular/core';
 import { DOCUMENT } from '@angular/common';
+import { Component, Inject, Input, OnChanges, OnDestroy, OnInit, Renderer2 } from '@angular/core';
 
 @Component({
   selector: 'pdf-dynamic-css',
@@ -60,7 +60,7 @@ export class DynamicCssComponent implements OnInit, OnChanges, OnDestroy {
 }
 
 @media all and (max-width: ${this.lg}px) {
-  .toolbarButtonSpacer {
+  #outerContainer .toolbarButtonSpacer {
     width: 15px;
   }
 
@@ -73,7 +73,7 @@ export class DynamicCssComponent implements OnInit, OnChanges, OnDestroy {
 }
 
 @media all and (max-width: ${this.md}px) {
-  .toolbarButtonSpacer {
+  #outerContainer .toolbarButtonSpacer {
     display: none;
   }
   #outerContainer .hiddenMediumView {
@@ -85,14 +85,14 @@ export class DynamicCssComponent implements OnInit, OnChanges, OnDestroy {
 }
 
 @media all and (max-width: ${this.sm}px) {
-  .hiddenSmallView,
-  .hiddenSmallView * {
+  #outerContainer .hiddenSmallView,
+  #outerContainer .hiddenSmallView * {
     display: none;
   }
-  .visibleSmallView {
+  #outerContainer .visibleSmallView {
     display: inherit;
   }
-  .toolbarButtonSpacer {
+  #outerContainer .toolbarButtonSpacer {
     width: 0;
   }
   html[dir='ltr'] .findbar {
@@ -109,14 +109,14 @@ export class DynamicCssComponent implements OnInit, OnChanges, OnDestroy {
   }
 }
 
-.visibleXLView,
-.visibleXXLView,
-.visibleTinyView {
+#outerContainer .visibleXLView,
+#outerContainer .visibleXXLView,
+#outerContainer .visibleTinyView {
   display: none;
 }
 
-.hiddenXLView,
-.hiddenXXLView {
+#outerContainer .hiddenXLView,
+#outerContainer .hiddenXXLView {
   display: unset;
 }
 
@@ -155,11 +155,11 @@ export class DynamicCssComponent implements OnInit, OnChanges, OnDestroy {
 }
 
 @media all and (max-width: ${this.xs}px) {
-  .hiddenTinyView,
-  .hiddenTinyView * {
+  #outerContainer .hiddenTinyView,
+  #outerContainer .hiddenTinyView * {
     display: none;
   }
-  .visibleTinyView {
+  #outerContainer .visibleTinyView {
     display: inherit;
   }
 }


### PR DESCRIPTION
Missing `#outerContainer` in some dynamic CSS selectors leads to certain selectors being overridden by more specific ones that include it.

One issue was that the download-button was not shown neither in the secondary menu nor in the toolbar when the pdf-viewer was very narrow since the `.visibleSmallView { display: inherit; }` was ignored.

| Before | After |
| ------- | ----- |
| ![pdfjs-before](https://user-images.githubusercontent.com/6369346/104045335-b2d7aa80-51de-11eb-9c72-3af973571301.png) | ![pdfjs-after](https://user-images.githubusercontent.com/6369346/104045343-b53a0480-51de-11eb-9484-31f58f068d97.png) |

