### PR TITLE
setting error message text color to the right SCSS variable

### DIFF
--- a/projects/ngx-extended-pdf-viewer/src/lib/theme/common/viewer-with-images.scss
+++ b/projects/ngx-extended-pdf-viewer/src/lib/theme/common/viewer-with-images.scss
@@ -1530,7 +1530,7 @@ ngx-extended-pdf-viewer {
 
   #errorMoreInfo {
     background-color: $page-background;
-    color: $background;
+    color: $error-color;
     padding: 3px;
     margin: 3px;
     width: 98%;


### PR DESCRIPTION
fixed the color text bug (being the same as it's background). 

How does it look ? -->
![image](https://user-images.githubusercontent.com/28602203/110216320-cdf92a80-7eae-11eb-9520-3e725cc1ddbc.png)
