### PR TITLE
better handle when toolbar is undefined

### DIFF
--- a/projects/ngx-extended-pdf-viewer/src/lib/ngx-extended-pdf-viewer.component.ts
+++ b/projects/ngx-extended-pdf-viewer/src/lib/ngx-extended-pdf-viewer.component.ts
@@ -547,6 +547,9 @@ export class NgxExtendedPdfViewerComponent implements OnInit, AfterViewInit, OnC
 
   public calcViewerPositionTop(): void {
     const toolbar = document.getElementsByClassName("toolbar")[0] as HTMLElement;
+    if (toolbar === undefined) {
+      return;
+    }
     let top = toolbar.getBoundingClientRect().height;
     this.viewerPositionTop = top + "px";
 


### PR DESCRIPTION
in 7.3.2 it was working OK
in 8.2.0 there is error
fix error in latest version :
ERROR TypeError: Cannot read property 'getBoundingClientRect' of undefined
    at NgxExtendedPdfViewerComponent.calcViewerPositionTop (ngx-extended-pdf-viewer.component.ts:546)
    at ngx-extended-pdf-viewer.component.ts:1529