### PR TITLE
Check for optional chaining browser support

### DIFF
--- a/projects/ngx-extended-pdf-viewer/assets/op-chaining-support.js
+++ b/projects/ngx-extended-pdf-viewer/assets/op-chaining-support.js
@@ -1,0 +1,5 @@
+const optionalChaining = {
+  support: true,
+};
+
+window.supportsOptionalChaining = optionalChaining?.support;


### PR DESCRIPTION
This PR adds a check for browser's optional chaining native support. When a browser doesn't support optional chaining, it throws a SyntaxError, which has the following effects:
- It cannot be caught with try/catch blocks, since it's thrown by the parser, not by the runtime (there are exceptions, like JSON.parse());
- It kills the thread parsing the code;
Because of these reasons, the check script must be run in a separated space (when running it like a normal function inside an Angular component, it crashes the main thread, stopping all rendering).

The solution was using the same approach used to load PDF.js: dinamically adding a script tag with the check script as source and listening to onload and onerror events. As this check needs to happen before loading PDF.js, I've encapsulated this in a Promise.

Also, there's a minor refactoring: since this approach was being used in three different places, I moved the HTMLScriptElement creation and the logic to create the path to separated methods.