### PR TITLE
Remove call to console log on module import

### DIFF
--- a/projects/ngx-extended-pdf-viewer/src/lib/ngx-extended-pdf-viewer.module.ts
+++ b/projects/ngx-extended-pdf-viewer/src/lib/ngx-extended-pdf-viewer.module.ts
@@ -54,9 +54,6 @@ import { NgxConsole } from './options/ngx-console';
 import { PdfFindCurrentPageOnlyComponent } from './toolbar/pdf-findbar/pdf-find-current-page-only/pdf-find-current-page-only.component';
 import { PdfFindRangeComponent } from './toolbar/pdf-findbar/pdf-find-range/pdf-find-range.component';
 
-
-new NgxConsole().log('');
-
 if (!Promise['allSettled']) {
   if (!!window['Zone'] && !window['__zone_symbol__Promise.allSettled']) {
     console.error(


### PR DESCRIPTION
This line causes numerous logs from the library in various places like unit tests etc because just an import causes a log line to be written