### PR TITLE
FIX: Use the 'toolbar' from the pdf-toolbar component instead of first in document.

### DIFF
--- a/projects/ngx-extended-pdf-viewer/src/lib/ngx-extended-pdf-viewer.component.html
+++ b/projects/ngx-extended-pdf-viewer/src/lib/ngx-extended-pdf-viewer.component.html
@@ -41,6 +41,7 @@
             [textLayer]="textLayer"
             [toolbarMarginTop]="toolbarMarginTop"
             [toolbarWidth]="toolbarWidth"
+            (onToolbarLoaded)="onToolbarLoaded"
             [zoomLevels]="zoomLevels"
           ></pdf-toolbar>
 

--- a/projects/ngx-extended-pdf-viewer/src/lib/ngx-extended-pdf-viewer.component.ts
+++ b/projects/ngx-extended-pdf-viewer/src/lib/ngx-extended-pdf-viewer.component.ts
@@ -626,6 +626,11 @@ export class NgxExtendedPdfViewerComponent implements OnInit, AfterViewInit, OnC
 
   public toolbarWidth = '100%';
 
+  private toolbar: HTMLElement | undefined = undefined;
+  public onToolbarLoaded(toolbarElement: HTMLElement): void {
+      this.toolbar = toolbarElement;
+  }
+
   public toolbarWidthInPixels = 100;
 
   public secondaryToolbarTop: string | undefined = undefined;
@@ -673,11 +678,10 @@ export class NgxExtendedPdfViewerComponent implements OnInit, AfterViewInit, OnC
   private shuttingDown = false;
 
   public calcViewerPositionTop(): void {
-    const toolbar = document.getElementsByClassName('toolbar')[0] as HTMLElement;
-    if (toolbar === undefined) {
+    if (this.toolbar === undefined) {
       return;
     }
-    let top = toolbar.getBoundingClientRect().height;
+    let top = this.toolbar.getBoundingClientRect().height;
     this.viewerPositionTop = top + 'px';
 
     const factor = top / 33;
@@ -688,7 +692,7 @@ export class NgxExtendedPdfViewerComponent implements OnInit, AfterViewInit, OnC
 
     const findButton = document.getElementById('viewFind');
     if (findButton) {
-      const containerPositionLeft = toolbar.getBoundingClientRect().left;
+      const containerPositionLeft = this.toolbar.getBoundingClientRect().left;
       const findButtonPosition = findButton.getBoundingClientRect();
       const left = findButtonPosition.left - containerPositionLeft;
       this.findbarLeft = left + 'px';

--- a/projects/ngx-extended-pdf-viewer/src/lib/toolbar/pdf-toolbar/pdf-toolbar.component.ts
+++ b/projects/ngx-extended-pdf-viewer/src/lib/toolbar/pdf-toolbar/pdf-toolbar.component.ts
@@ -1,4 +1,5 @@
-import { Component, OnInit, Input, TemplateRef, Output, EventEmitter } from '@angular/core';
+import { ElementRef } from '@angular/core';
+import { Component, Input, TemplateRef, Output, EventEmitter } from '@angular/core';
 
 @Component({
   selector: 'pdf-toolbar',
@@ -63,5 +64,12 @@ export class PdfToolbarComponent {
   @Input()
   public zoomLevels = ['auto', 'page-actual', 'page-fit', 'page-width', 0.5, 0.75, 1, 1.25, 1.5, 2, 3, 4];
 
-  constructor() {}
+  @Output()
+  public onToolbarLoaded = new EventEmitter<HTMLElement>();
+
+  constructor(elementRef: ElementRef) {
+    this.onToolbarLoaded.emit(elementRef.nativeElement.getElementsByClassName('toolbar')[0] as HTMLElement);
+  }
+  
+
 }


### PR DESCRIPTION
BUG: When a div or other HTML element outside of the ngx-extended-pdf-viewer (pdf-viewer) module uses a class name 'toolbar' it causes wrong behaviour since de pdf-viewer gets the element by class name in the whole document. 

Native javascript in angular components is bad practise right?

FIXED: It will now output the required html element using the elementref injection.