### PR TITLE
Fix button type in document properties

### DIFF
--- a/projects/ngx-extended-pdf-viewer/src/lib/pdf-dialog/pdf-document-properties-dialog/pdf-document-properties-dialog.component.html
+++ b/projects/ngx-extended-pdf-viewer/src/lib/pdf-dialog/pdf-document-properties-dialog/pdf-document-properties-dialog.component.html
@@ -59,6 +59,6 @@
     <p id="linearizedField" aria-labelledby="linearizedLabel">-</p>
   </div>
   <div class="buttonRow">
-    <button id="documentPropertiesClose" class="dialogButton"><span data-l10n-id="document_properties_close">Close</span></button>
+    <button id="documentPropertiesClose" class="dialogButton" type="button"><span data-l10n-id="document_properties_close">Close</span></button>
   </div>
 </dialog>


### PR DESCRIPTION
The default button type is "submit" which submits the surrounding form.
A button type should always be specified to avoid accidentally submitting surrounding forms.

related to issue: #1546