### PR TITLE
Enable "withCredentials" option without "Authorization" header

### DIFF
--- a/projects/ngx-extended-pdf-viewer/src/lib/ngx-extended-pdf-viewer.component.ts
+++ b/projects/ngx-extended-pdf-viewer/src/lib/ngx-extended-pdf-viewer.component.ts
@@ -18,7 +18,7 @@ import {
   Renderer2,
   SimpleChanges,
   TemplateRef,
-  ViewChild,
+  ViewChild
 } from '@angular/core';
 import { Annotation } from './Annotation';
 import { PdfDocumentLoadedEvent } from './events/document-loaded-event';
@@ -1413,7 +1413,7 @@ export class NgxExtendedPdfViewerComponent implements OnInit, AfterViewInit, OnC
     if (this._src) {
       this.ngxExtendedPdfViewerIncompletelyInitialized = false;
       if (!this.listenToURL) {
-        PDFViewerApplication.pdfLinkService.setHash = function () {};
+        PDFViewerApplication.pdfLinkService.setHash = function () { };
       }
       this.initTimeout = null;
       this.selectCursorTool();
@@ -1603,14 +1603,11 @@ export class NgxExtendedPdfViewerComponent implements OnInit, AfterViewInit, OnC
         }
         if (this.authorization) {
           options.withCredentials = true;
-          if (options.httpHeaders) {
-            if (!options.httpHeaders.Authorization) {
-              options.httpHeaders.Authorization = this.authorization;
-            }
-          } else {
-            options.httpHeaders = {
-              Authorization: this.authorization,
-            };
+
+          if (typeof this.authorization != "boolean") {
+            if (!options.httpHeaders) options.httpHeaders = {};
+
+            options.httpHeaders.Authorization = this.authorization;
           }
         }
         options.baseHref = this.baseHref;
@@ -1689,14 +1686,11 @@ export class NgxExtendedPdfViewerComponent implements OnInit, AfterViewInit, OnC
     }
     if (this.authorization) {
       options.withCredentials = true;
-      if (options.httpHeaders) {
-        if (!options.httpHeaders.Authorization) {
-          options.httpHeaders.Authorization = this.authorization;
-        }
-      } else {
-        options.httpHeaders = {
-          Authorization: this.authorization,
-        };
+
+      if (typeof this.authorization != "boolean") {
+        if (!options.httpHeaders) options.httpHeaders = {};
+
+        options.httpHeaders.Authorization = this.authorization;
       }
     }
     options.baseHref = this.baseHref;


### PR DESCRIPTION
It allows to enable "withCredentials" in the file request without mandatory use of Authorization header.
If authorization input is just a boolean like "true", withCredentials option is set. Also, if authorization input is defined and is not a boolean, Autorization header is set as before.

Related issue: #635 