### PR TITLE
Bug in hasPageBeenRendered method

### DIFF
--- a/projects/ngx-extended-pdf-viewer/src/lib/ngx-extended-pdf-viewer.service.ts
+++ b/projects/ngx-extended-pdf-viewer/src/lib/ngx-extended-pdf-viewer.service.ts
@@ -399,7 +399,7 @@ export class NgxExtendedPdfViewerService {
     if (pages.length > pageIndex && pageIndex >= 0) {
       const pageView = pages[pageIndex];
       const hasBeenRendered  = pageView.renderingState === 3;
-      return hasBeenRendered ;
+      return hasBeenRendered;
     }
     return false;
   }

--- a/projects/ngx-extended-pdf-viewer/src/lib/ngx-extended-pdf-viewer.service.ts
+++ b/projects/ngx-extended-pdf-viewer/src/lib/ngx-extended-pdf-viewer.service.ts
@@ -398,8 +398,8 @@ export class NgxExtendedPdfViewerService {
     const pages = PDFViewerApplication.pdfViewer._pages;
     if (pages.length > pageIndex && pageIndex >= 0) {
       const pageView = pages[pageIndex];
-      const isRendered = pageView.renderingState === 3;
-      return isRendered;
+      const hasBeenRendered  = pageView.renderingState === 3;
+      return hasBeenRendered ;
     }
     return false;
   }

--- a/projects/ngx-extended-pdf-viewer/src/lib/ngx-extended-pdf-viewer.service.ts
+++ b/projects/ngx-extended-pdf-viewer/src/lib/ngx-extended-pdf-viewer.service.ts
@@ -398,8 +398,8 @@ export class NgxExtendedPdfViewerService {
     const pages = PDFViewerApplication.pdfViewer._pages;
     if (pages.length > pageIndex && pageIndex >= 0) {
       const pageView = pages[pageIndex];
-      const isLoading = pageView.renderingState === 3;
-      return !isLoading;
+      const isRendered = pageView.renderingState === 3;
+      return isRendered;
     }
     return false;
   }


### PR DESCRIPTION
- I have looked at the pdf.js 's rendering states and noticed that renderingState == 3 means the page rendering is fully finished. That means the `isLoading` variable is misleading in this context. Also, the `!isLoading` statement is incorrect because if the page is fully rendered, why don't we just return whatever value comes from the check `pageView.renderingState === 3`.  Negating the variable does not return the correct state. 
- My suggestion is to rename the variable to `isRendered` and return it. Or I could return the inline statement `return pageView.renderingState === 3`
- I looked at the previous implementation and it was correct since you used the `.loading` container to mark pages has not been fully rendered
- [Link to pdf.js 's RenderingStates](https://github.com/mozilla/pdf.js/blob/master/web/ui_utils.js)
