### PR TITLE
Fix: Move inline styles into CSS classes to comply with strict Content-Security-Policy (CSP) guidelines

### DIFF
--- a/compatibility-tests/common/demo/src/app/find/find.component.css
+++ b/compatibility-tests/common/demo/src/app/find/find.component.css
@@ -2,6 +2,10 @@
   margin-left: 24px;
 }
 
+.margin-left-10px {
+  margin-left: 10px;
+}
+
 .button-box {
   margin-top: 5px;
   margin-bottom: 10px;

--- a/compatibility-tests/common/demo/src/app/find/find.component.html
+++ b/compatibility-tests/common/demo/src/app/find/find.component.html
@@ -28,7 +28,7 @@
 </section>
 <section class="section button-box">
   <button id="gotoNextPage" (click)="findNext()">next</button>
-  <button id="gotoPreviousPage" (click)="findPrevious()" style="margin-left: 10px">previous</button>
+  <button id="gotoPreviousPage" (click)="findPrevious()" class="margin-left-10px">previous</button>
 </section>
 
 <section>

--- a/projects/ngx-extended-pdf-viewer/src/lib/toolbar/pdf-rotate-page-ccw/pdf-rotate-page-ccw.component.css
+++ b/projects/ngx-extended-pdf-viewer/src/lib/toolbar/pdf-rotate-page-ccw/pdf-rotate-page-ccw.component.css
@@ -15,3 +15,8 @@ button {
   margin-top: 0;
   margin-bottom: 0;
 }
+
+.width-height-23px {
+  width: 23px; 
+  height: 23px;
+}

--- a/projects/ngx-extended-pdf-viewer/src/lib/toolbar/pdf-rotate-page-ccw/pdf-rotate-page-ccw.component.html
+++ b/projects/ngx-extended-pdf-viewer/src/lib/toolbar/pdf-rotate-page-ccw/pdf-rotate-page-ccw.component.html
@@ -10,6 +10,6 @@
   [disabled]="disableRotate"
   [order]="1000"
   [closeOnClick]="false"
-  image="<svg style='width: 23px; height: 23px' viewBox='0 0 24 24'><path fill='currentColor' d='M12 3C7.03 3 3 7.03 3 12H0L4 16L8 12H5C5 8.13 8.13 5 12 5S19 8.13 19 12 15.87 19 12 19C10.55 19 9.13 18.54 7.94 17.7L6.5 19.14C8.08 20.34 10 21 12 21C16.97 21 21 16.97 21 12S16.97 3 12 3'/></svg>"
+  image="<svg class='width-height-23px' viewBox='0 0 24 24'><path fill='currentColor' d='M12 3C7.03 3 3 7.03 3 12H0L4 16L8 12H5C5 8.13 8.13 5 12 5S19 8.13 19 12 15.87 19 12 19C10.55 19 9.13 18.54 7.94 17.7L6.5 19.14C8.08 20.34 10 21 12 21C16.97 21 21 16.97 21 12S16.97 3 12 3'/></svg>"
 >
 </pdf-shy-button>

--- a/projects/ngx-extended-pdf-viewer/src/lib/toolbar/pdf-rotate-page-cw/pdf-rotate-page-cw.component.css
+++ b/projects/ngx-extended-pdf-viewer/src/lib/toolbar/pdf-rotate-page-cw/pdf-rotate-page-cw.component.css
@@ -15,3 +15,8 @@ button {
   margin-top: 0;
   margin-bottom: 0;
 }
+
+.width-height-23px {
+  width: 23px; 
+  height: 23px;
+}

--- a/projects/ngx-extended-pdf-viewer/src/lib/toolbar/pdf-rotate-page-cw/pdf-rotate-page-cw.component.html
+++ b/projects/ngx-extended-pdf-viewer/src/lib/toolbar/pdf-rotate-page-cw/pdf-rotate-page-cw.component.html
@@ -10,6 +10,6 @@
   [disabled]="disableRotate"
   [order]="900"
   [closeOnClick]="false"
-  image="<svg style='width: 23px; height: 23px' viewBox='0 0 24 24'><path fill='currentColor' d='M12 3C7.03 3 3 7.03 3 12S7.03 21 12 21C14 21 15.92 20.34 17.5 19.14L16.06 17.7C14.87 18.54 13.45 19 12 19C8.13 19 5 15.87 5 12S8.13 5 12 5 19 8.13 19 12H16L20 16L24 12H21C21 7.03 16.97 3 12 3'/></svg>"
+  image="<svg class='width-height-23px' viewBox='0 0 24 24'><path fill='currentColor' d='M12 3C7.03 3 3 7.03 3 12S7.03 21 12 21C14 21 15.92 20.34 17.5 19.14L16.06 17.7C14.87 18.54 13.45 19 12 19C8.13 19 5 15.87 5 12S8.13 5 12 5 19 8.13 19 12H16L20 16L24 12H21C21 7.03 16.97 3 12 3'/></svg>"
 >
 </pdf-shy-button>


### PR DESCRIPTION
Partial fix for:
#2362 [Content Security Policy headers: 'nonce' key not working](https://github.com/stephanrauh/ngx-extended-pdf-viewer/issues/2362)

Check linked comment on discussion.