### PR TITLE
fix: fixed tailwind interfering with PDF Viewer icons in showcase

### DIFF
--- a/projects/showcase/src/styles.css
+++ b/projects/showcase/src/styles.css
@@ -243,6 +243,13 @@
       @apply dark:bg-primary-variant-hover-dark/60;
     }
   }
+
+  ngx-extended-pdf-viewer {
+    svg {
+      display: unset;
+      vertical-align: unset;
+    }
+  }
 }
 
 .material-symbols-outlined {


### PR DESCRIPTION
Fixes the icons in the PDF Viewer Toolbar looking weird on the showcase page