### PR TITLE
Capitalize label for consistency

### DIFF
--- a/projects/ngx-extended-pdf-viewer/assets/additional-locale/en.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/additional-locale/en.ftl
@@ -15,5 +15,5 @@
 # Additional translations
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/ach/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/ach/viewer.ftl
@@ -431,5 +431,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/af/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/af/viewer.ftl
@@ -432,5 +432,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/an/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/an/viewer.ftl
@@ -438,5 +438,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/ar/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/ar/viewer.ftl
@@ -489,5 +489,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/ast/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/ast/viewer.ftl
@@ -413,5 +413,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/az/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/az/viewer.ftl
@@ -438,5 +438,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/be/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/be/viewer.ftl
@@ -520,5 +520,5 @@ pdfjs-editor-undo-bar-close-button-label = Закрыць
 # Translations for ngx-extended-pdf-viewer additions only available in en-US
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/bg/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/bg/viewer.ftl
@@ -490,5 +490,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/bn/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/bn/viewer.ftl
@@ -434,5 +434,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/bo/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/bo/viewer.ftl
@@ -434,5 +434,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/br/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/br/viewer.ftl
@@ -465,5 +465,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/brx/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/brx/viewer.ftl
@@ -432,5 +432,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/bs/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/bs/viewer.ftl
@@ -432,5 +432,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/ca/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/ca/viewer.ftl
@@ -464,5 +464,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/cak/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/cak/viewer.ftl
@@ -442,5 +442,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/ckb/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/ckb/viewer.ftl
@@ -434,5 +434,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/cs/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/cs/viewer.ftl
@@ -523,5 +523,5 @@ pdfjs-editor-undo-bar-close-button-label = Zavřít
 # Translations for ngx-extended-pdf-viewer additions only available in en-US
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/cy/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/cy/viewer.ftl
@@ -529,5 +529,5 @@ pdfjs-editor-undo-bar-close-button-label = Cau
 # Translations for ngx-extended-pdf-viewer additions only available in en-US
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/da/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/da/viewer.ftl
@@ -517,5 +517,5 @@ pdfjs-editor-undo-bar-close-button-label = Luk
 # Translations for ngx-extended-pdf-viewer additions only available in en-US
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/dsb/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/dsb/viewer.ftl
@@ -523,5 +523,5 @@ pdfjs-editor-undo-bar-close-button-label = Zacyniś
 # Translations for ngx-extended-pdf-viewer additions only available in en-US
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/el/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/el/viewer.ftl
@@ -517,5 +517,5 @@ pdfjs-editor-undo-bar-close-button-label = Κλείσιμο
 # Translations for ngx-extended-pdf-viewer additions only available in en-US
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/en-CA/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/en-CA/viewer.ftl
@@ -517,5 +517,5 @@ pdfjs-editor-undo-bar-close-button-label = Close
 # Additional translations for ngx-extended-pdf-viewer (en)
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/en-GB/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/en-GB/viewer.ftl
@@ -517,5 +517,5 @@ pdfjs-editor-undo-bar-close-button-label = Close
 # Additional translations for ngx-extended-pdf-viewer (en)
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/en-US/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/en-US/viewer.ftl
@@ -528,5 +528,5 @@ pdfjs-editor-undo-bar-close-button-label = Close
 # Additional translations for ngx-extended-pdf-viewer (en)
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/eo/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/eo/viewer.ftl
@@ -517,5 +517,5 @@ pdfjs-editor-undo-bar-close-button-label = Fermi
 # Translations for ngx-extended-pdf-viewer additions only available in en-US
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/et/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/et/viewer.ftl
@@ -440,5 +440,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/eu/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/eu/viewer.ftl
@@ -517,5 +517,5 @@ pdfjs-editor-undo-bar-close-button-label = Itxi
 # Translations for ngx-extended-pdf-viewer additions only available in en-US
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/fa/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/fa/viewer.ftl
@@ -473,5 +473,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/ff/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/ff/viewer.ftl
@@ -434,5 +434,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/fi/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/fi/viewer.ftl
@@ -517,5 +517,5 @@ pdfjs-editor-undo-bar-close-button-label = Sulje
 # Translations for ngx-extended-pdf-viewer additions only available in en-US
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/fur/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/fur/viewer.ftl
@@ -502,5 +502,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/fy-NL/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/fy-NL/viewer.ftl
@@ -517,5 +517,5 @@ pdfjs-editor-undo-bar-close-button-label = Slute
 # Translations for ngx-extended-pdf-viewer additions only available in en-US
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/ga-IE/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/ga-IE/viewer.ftl
@@ -432,5 +432,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/gd/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/gd/viewer.ftl
@@ -464,5 +464,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/gl/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/gl/viewer.ftl
@@ -480,5 +480,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/gn/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/gn/viewer.ftl
@@ -517,5 +517,5 @@ pdfjs-editor-undo-bar-close-button-label = Mboty
 # Translations for ngx-extended-pdf-viewer additions only available in en-US
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/gu-IN/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/gu-IN/viewer.ftl
@@ -434,5 +434,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/he/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/he/viewer.ftl
@@ -517,5 +517,5 @@ pdfjs-editor-undo-bar-close-button-label = סגירה
 # Translations for ngx-extended-pdf-viewer additions only available in en-US
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/hi-IN/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/hi-IN/viewer.ftl
@@ -457,5 +457,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/hr/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/hr/viewer.ftl
@@ -499,5 +499,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/hsb/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/hsb/viewer.ftl
@@ -523,5 +523,5 @@ pdfjs-editor-undo-bar-close-button-label = Začinić
 # Translations for ngx-extended-pdf-viewer additions only available in en-US
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/hu/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/hu/viewer.ftl
@@ -517,5 +517,5 @@ pdfjs-editor-undo-bar-close-button-label = Bezárás
 # Translations for ngx-extended-pdf-viewer additions only available in en-US
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/hy-AM/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/hy-AM/viewer.ftl
@@ -450,5 +450,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/hye/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/hye/viewer.ftl
@@ -440,5 +440,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/ia/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/ia/viewer.ftl
@@ -517,5 +517,5 @@ pdfjs-editor-undo-bar-close-button-label = Clauder
 # Translations for ngx-extended-pdf-viewer additions only available in en-US
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/id/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/id/viewer.ftl
@@ -475,5 +475,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/is/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/is/viewer.ftl
@@ -517,5 +517,5 @@ pdfjs-editor-undo-bar-close-button-label = Loka
 # Translations for ngx-extended-pdf-viewer additions only available in en-US
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/it/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/it/viewer.ftl
@@ -518,5 +518,5 @@ pdfjs-editor-undo-bar-close-button-label = Chiudi
 unverified-signature-warning = Questo file PDF contiene una firma digitale. Questo visualizzatore PDF non può verificare se la firma è valida. Scarica il file e aprilo in Acrobat Reader per verificare che la firma sia valida.
 # Translations for ngx-extended-pdf-viewer additions only available in en-US
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/ja/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/ja/viewer.ftl
@@ -505,5 +505,5 @@ pdfjs-editor-undo-bar-close-button-label = 閉じる
 # Translations for ngx-extended-pdf-viewer additions only available in en-US
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/ka/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/ka/viewer.ftl
@@ -517,5 +517,5 @@ pdfjs-editor-undo-bar-close-button-label = დახურვა
 # Translations for ngx-extended-pdf-viewer additions only available in en-US
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/kab/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/kab/viewer.ftl
@@ -491,5 +491,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/kk/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/kk/viewer.ftl
@@ -517,5 +517,5 @@ pdfjs-editor-undo-bar-close-button-label = Жабу
 # Translations for ngx-extended-pdf-viewer additions only available in en-US
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/km/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/km/viewer.ftl
@@ -430,5 +430,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/kn/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/kn/viewer.ftl
@@ -429,5 +429,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/ko/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/ko/viewer.ftl
@@ -505,5 +505,5 @@ pdfjs-editor-undo-bar-close-button-label = 닫기
 # Translations for ngx-extended-pdf-viewer additions only available in en-US
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/lij/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/lij/viewer.ftl
@@ -434,5 +434,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/lo/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/lo/viewer.ftl
@@ -464,5 +464,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/lt/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/lt/viewer.ftl
@@ -440,5 +440,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/ltg/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/ltg/viewer.ftl
@@ -434,5 +434,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/lv/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/lv/viewer.ftl
@@ -434,5 +434,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/meh/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/meh/viewer.ftl
@@ -406,5 +406,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/mk/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/mk/viewer.ftl
@@ -428,5 +428,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/mr/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/mr/viewer.ftl
@@ -438,5 +438,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/ms/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/ms/viewer.ftl
@@ -434,5 +434,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/my/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/my/viewer.ftl
@@ -432,5 +432,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/nb-NO/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/nb-NO/viewer.ftl
@@ -512,5 +512,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/ne-NP/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/ne-NP/viewer.ftl
@@ -431,5 +431,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/nl/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/nl/viewer.ftl
@@ -518,5 +518,5 @@ pdfjs-editor-undo-bar-close-button-label = Sluiten
 unverified-signature-warning = Deze PDF bevat een digitale handtekening. De PDF viewer kan de geldigheid niet controleren. Gelieve het bestand te downloaden en te openen in Acrobat Reader om de handtekening te controleren.
 # Translations for ngx-extended-pdf-viewer additions only available in en-US
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/nn-NO/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/nn-NO/viewer.ftl
@@ -515,5 +515,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/oc/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/oc/viewer.ftl
@@ -477,5 +477,5 @@ pdfjs-editor-undo-bar-message-multiple =
     }
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/pa-IN/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/pa-IN/viewer.ftl
@@ -517,5 +517,5 @@ pdfjs-editor-undo-bar-close-button-label = ਬੰਦ ਕਰੋ
 # Translations for ngx-extended-pdf-viewer additions only available in en-US
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/pl/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/pl/viewer.ftl
@@ -520,5 +520,5 @@ pdfjs-editor-undo-bar-close-button-label = Zamknij
 # Translations for ngx-extended-pdf-viewer additions only available in en-US
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/pt-BR/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/pt-BR/viewer.ftl
@@ -518,5 +518,5 @@ pdfjs-editor-undo-bar-close-button-label = Fechar
 unverified-signature-warning = Este arquivo PDF contém uma assinatura digital. O visualizador de PDF não pode verificar se a assinatura é válida. Faça download do arquivo e abra-o no Acrobat Reader para verificar se a assinatura é válida.
 # Translations for ngx-extended-pdf-viewer additions only available in en-US
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/pt-PT/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/pt-PT/viewer.ftl
@@ -518,5 +518,5 @@ pdfjs-editor-undo-bar-close-button-label = Fechar
 unverified-signature-warning = Este arquivo PDF contém uma assinatura digital. O visualizador de PDF não pode verificar se a assinatura é válida. Faça download do arquivo e abra-o no Acrobat Reader para verificar se a assinatura é válida.
 # Translations for ngx-extended-pdf-viewer additions only available in en-US
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/rm/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/rm/viewer.ftl
@@ -517,5 +517,5 @@ pdfjs-editor-undo-bar-close-button-label = Serrar
 # Translations for ngx-extended-pdf-viewer additions only available in en-US
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/ro/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/ro/viewer.ftl
@@ -438,5 +438,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/ru/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/ru/viewer.ftl
@@ -520,5 +520,5 @@ pdfjs-editor-undo-bar-close-button-label = Закрыть
 # Translations for ngx-extended-pdf-viewer additions only available in en-US
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/sat/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/sat/viewer.ftl
@@ -467,5 +467,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/sc/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/sc/viewer.ftl
@@ -462,5 +462,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/scn/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/scn/viewer.ftl
@@ -402,5 +402,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/sco/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/sco/viewer.ftl
@@ -440,5 +440,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/si/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/si/viewer.ftl
@@ -455,5 +455,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/sk/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/sk/viewer.ftl
@@ -523,5 +523,5 @@ pdfjs-editor-undo-bar-close-button-label = Zavrieť
 # Translations for ngx-extended-pdf-viewer additions only available in en-US
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/skr/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/skr/viewer.ftl
@@ -512,5 +512,5 @@ pdfjs-editor-undo-bar-message-multiple =
     }
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/sl/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/sl/viewer.ftl
@@ -524,5 +524,5 @@ pdfjs-editor-undo-bar-close-button-label = Zapri
 unverified-signature-warning = Dokument vsebuje digitalni podpis. PDF viewer ne more preveriti veljavnost podpisa. Prosimo prenesite dokument in veljavnost podpisa preverite v programu Acrobat Reader.
 # Translations for ngx-extended-pdf-viewer additions only available in en-US
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/son/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/son/viewer.ftl
@@ -432,5 +432,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/sq/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/sq/viewer.ftl
@@ -517,5 +517,5 @@ pdfjs-spread-even-button =
 pdfjs-spread-even-button-label = Even Spreads
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/sr/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/sr/viewer.ftl
@@ -485,5 +485,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/sv-SE/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/sv-SE/viewer.ftl
@@ -517,5 +517,5 @@ pdfjs-editor-undo-bar-close-button-label = Stäng
 # Translations for ngx-extended-pdf-viewer additions only available in en-US
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/szl/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/szl/viewer.ftl
@@ -438,5 +438,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/ta/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/ta/viewer.ftl
@@ -432,5 +432,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/te/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/te/viewer.ftl
@@ -432,5 +432,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/tg/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/tg/viewer.ftl
@@ -517,5 +517,5 @@ pdfjs-editor-undo-bar-close-button-label = Пӯшидан
 # Translations for ngx-extended-pdf-viewer additions only available in en-US
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/th/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/th/viewer.ftl
@@ -505,5 +505,5 @@ pdfjs-editor-undo-bar-close-button-label = ปิด
 # Translations for ngx-extended-pdf-viewer additions only available in en-US
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/tl/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/tl/viewer.ftl
@@ -438,5 +438,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/tr/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/tr/viewer.ftl
@@ -517,5 +517,5 @@ pdfjs-editor-undo-bar-close-button-label = Kapat
 # Translations for ngx-extended-pdf-viewer additions only available in en-US
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/trs/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/trs/viewer.ftl
@@ -419,5 +419,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/uk/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/uk/viewer.ftl
@@ -520,5 +520,5 @@ pdfjs-editor-undo-bar-close-button-label = Закрити
 # Translations for ngx-extended-pdf-viewer additions only available in en-US
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/ur/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/ur/viewer.ftl
@@ -436,5 +436,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/uz/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/uz/viewer.ftl
@@ -424,5 +424,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/vi/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/vi/viewer.ftl
@@ -505,5 +505,5 @@ pdfjs-editor-undo-bar-close-button-label = Đóng
 # Translations for ngx-extended-pdf-viewer additions only available in en-US
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/wo/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/wo/viewer.ftl
@@ -409,5 +409,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/xh/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/xh/viewer.ftl
@@ -432,5 +432,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/zh-CN/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/zh-CN/viewer.ftl
@@ -505,5 +505,5 @@ pdfjs-editor-undo-bar-close-button-label = 关闭
 # Translations for ngx-extended-pdf-viewer additions only available in en-US
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/assets/locale/zh-TW/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/assets/locale/zh-TW/viewer.ftl
@@ -505,5 +505,5 @@ pdfjs-editor-undo-bar-close-button-label = 關閉
 # Translations for ngx-extended-pdf-viewer additions only available in en-US
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/ach/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/ach/viewer.ftl
@@ -431,5 +431,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/af/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/af/viewer.ftl
@@ -432,5 +432,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/an/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/an/viewer.ftl
@@ -438,5 +438,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/ar/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/ar/viewer.ftl
@@ -489,5 +489,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/ast/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/ast/viewer.ftl
@@ -413,5 +413,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/az/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/az/viewer.ftl
@@ -438,5 +438,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/be/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/be/viewer.ftl
@@ -520,5 +520,5 @@ pdfjs-editor-undo-bar-close-button-label = Закрыць
 # Translations for ngx-extended-pdf-viewer additions only available in en-US
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/bg/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/bg/viewer.ftl
@@ -490,5 +490,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/bn/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/bn/viewer.ftl
@@ -434,5 +434,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/bo/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/bo/viewer.ftl
@@ -434,5 +434,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/br/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/br/viewer.ftl
@@ -465,5 +465,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/brx/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/brx/viewer.ftl
@@ -432,5 +432,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/bs/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/bs/viewer.ftl
@@ -432,5 +432,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/ca/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/ca/viewer.ftl
@@ -464,5 +464,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/cak/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/cak/viewer.ftl
@@ -442,5 +442,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/ckb/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/ckb/viewer.ftl
@@ -434,5 +434,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/cs/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/cs/viewer.ftl
@@ -523,5 +523,5 @@ pdfjs-editor-undo-bar-close-button-label = Zavřít
 # Translations for ngx-extended-pdf-viewer additions only available in en-US
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/cy/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/cy/viewer.ftl
@@ -529,5 +529,5 @@ pdfjs-editor-undo-bar-close-button-label = Cau
 # Translations for ngx-extended-pdf-viewer additions only available in en-US
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/da/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/da/viewer.ftl
@@ -517,5 +517,5 @@ pdfjs-editor-undo-bar-close-button-label = Luk
 # Translations for ngx-extended-pdf-viewer additions only available in en-US
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/dsb/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/dsb/viewer.ftl
@@ -523,5 +523,5 @@ pdfjs-editor-undo-bar-close-button-label = Zacyniś
 # Translations for ngx-extended-pdf-viewer additions only available in en-US
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/el/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/el/viewer.ftl
@@ -517,5 +517,5 @@ pdfjs-editor-undo-bar-close-button-label = Κλείσιμο
 # Translations for ngx-extended-pdf-viewer additions only available in en-US
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/en-CA/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/en-CA/viewer.ftl
@@ -517,5 +517,5 @@ pdfjs-editor-undo-bar-close-button-label = Close
 # Additional translations for ngx-extended-pdf-viewer (en)
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/en-GB/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/en-GB/viewer.ftl
@@ -517,5 +517,5 @@ pdfjs-editor-undo-bar-close-button-label = Close
 # Additional translations for ngx-extended-pdf-viewer (en)
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/en-US/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/en-US/viewer.ftl
@@ -528,5 +528,5 @@ pdfjs-editor-undo-bar-close-button-label = Close
 # Additional translations for ngx-extended-pdf-viewer (en)
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/eo/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/eo/viewer.ftl
@@ -517,5 +517,5 @@ pdfjs-editor-undo-bar-close-button-label = Fermi
 # Translations for ngx-extended-pdf-viewer additions only available in en-US
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/et/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/et/viewer.ftl
@@ -440,5 +440,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/eu/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/eu/viewer.ftl
@@ -517,5 +517,5 @@ pdfjs-editor-undo-bar-close-button-label = Itxi
 # Translations for ngx-extended-pdf-viewer additions only available in en-US
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/fa/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/fa/viewer.ftl
@@ -473,5 +473,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/ff/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/ff/viewer.ftl
@@ -434,5 +434,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/fi/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/fi/viewer.ftl
@@ -517,5 +517,5 @@ pdfjs-editor-undo-bar-close-button-label = Sulje
 # Translations for ngx-extended-pdf-viewer additions only available in en-US
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/fur/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/fur/viewer.ftl
@@ -502,5 +502,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/fy-NL/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/fy-NL/viewer.ftl
@@ -517,5 +517,5 @@ pdfjs-editor-undo-bar-close-button-label = Slute
 # Translations for ngx-extended-pdf-viewer additions only available in en-US
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/ga-IE/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/ga-IE/viewer.ftl
@@ -432,5 +432,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/gd/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/gd/viewer.ftl
@@ -464,5 +464,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/gl/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/gl/viewer.ftl
@@ -480,5 +480,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/gn/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/gn/viewer.ftl
@@ -517,5 +517,5 @@ pdfjs-editor-undo-bar-close-button-label = Mboty
 # Translations for ngx-extended-pdf-viewer additions only available in en-US
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/gu-IN/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/gu-IN/viewer.ftl
@@ -434,5 +434,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/he/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/he/viewer.ftl
@@ -517,5 +517,5 @@ pdfjs-editor-undo-bar-close-button-label = סגירה
 # Translations for ngx-extended-pdf-viewer additions only available in en-US
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/hi-IN/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/hi-IN/viewer.ftl
@@ -457,5 +457,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/hr/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/hr/viewer.ftl
@@ -499,5 +499,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/hsb/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/hsb/viewer.ftl
@@ -523,5 +523,5 @@ pdfjs-editor-undo-bar-close-button-label = Začinić
 # Translations for ngx-extended-pdf-viewer additions only available in en-US
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/hu/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/hu/viewer.ftl
@@ -517,5 +517,5 @@ pdfjs-editor-undo-bar-close-button-label = Bezárás
 # Translations for ngx-extended-pdf-viewer additions only available in en-US
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/hy-AM/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/hy-AM/viewer.ftl
@@ -450,5 +450,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/hye/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/hye/viewer.ftl
@@ -440,5 +440,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/ia/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/ia/viewer.ftl
@@ -517,5 +517,5 @@ pdfjs-editor-undo-bar-close-button-label = Clauder
 # Translations for ngx-extended-pdf-viewer additions only available in en-US
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/id/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/id/viewer.ftl
@@ -475,5 +475,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/is/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/is/viewer.ftl
@@ -517,5 +517,5 @@ pdfjs-editor-undo-bar-close-button-label = Loka
 # Translations for ngx-extended-pdf-viewer additions only available in en-US
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/it/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/it/viewer.ftl
@@ -518,5 +518,5 @@ pdfjs-editor-undo-bar-close-button-label = Chiudi
 unverified-signature-warning = Questo file PDF contiene una firma digitale. Questo visualizzatore PDF non può verificare se la firma è valida. Scarica il file e aprilo in Acrobat Reader per verificare che la firma sia valida.
 # Translations for ngx-extended-pdf-viewer additions only available in en-US
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/ja/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/ja/viewer.ftl
@@ -505,5 +505,5 @@ pdfjs-editor-undo-bar-close-button-label = 閉じる
 # Translations for ngx-extended-pdf-viewer additions only available in en-US
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/ka/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/ka/viewer.ftl
@@ -517,5 +517,5 @@ pdfjs-editor-undo-bar-close-button-label = დახურვა
 # Translations for ngx-extended-pdf-viewer additions only available in en-US
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/kab/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/kab/viewer.ftl
@@ -491,5 +491,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/kk/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/kk/viewer.ftl
@@ -517,5 +517,5 @@ pdfjs-editor-undo-bar-close-button-label = Жабу
 # Translations for ngx-extended-pdf-viewer additions only available in en-US
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/km/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/km/viewer.ftl
@@ -430,5 +430,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/kn/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/kn/viewer.ftl
@@ -429,5 +429,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/ko/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/ko/viewer.ftl
@@ -505,5 +505,5 @@ pdfjs-editor-undo-bar-close-button-label = 닫기
 # Translations for ngx-extended-pdf-viewer additions only available in en-US
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/lij/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/lij/viewer.ftl
@@ -434,5 +434,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/lo/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/lo/viewer.ftl
@@ -464,5 +464,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/lt/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/lt/viewer.ftl
@@ -440,5 +440,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/ltg/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/ltg/viewer.ftl
@@ -434,5 +434,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/lv/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/lv/viewer.ftl
@@ -434,5 +434,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/meh/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/meh/viewer.ftl
@@ -406,5 +406,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/mk/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/mk/viewer.ftl
@@ -428,5 +428,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/mr/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/mr/viewer.ftl
@@ -438,5 +438,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/ms/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/ms/viewer.ftl
@@ -434,5 +434,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/my/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/my/viewer.ftl
@@ -432,5 +432,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/nb-NO/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/nb-NO/viewer.ftl
@@ -512,5 +512,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/ne-NP/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/ne-NP/viewer.ftl
@@ -431,5 +431,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/nl/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/nl/viewer.ftl
@@ -518,5 +518,5 @@ pdfjs-editor-undo-bar-close-button-label = Sluiten
 unverified-signature-warning = Deze PDF bevat een digitale handtekening. De PDF viewer kan de geldigheid niet controleren. Gelieve het bestand te downloaden en te openen in Acrobat Reader om de handtekening te controleren.
 # Translations for ngx-extended-pdf-viewer additions only available in en-US
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/nn-NO/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/nn-NO/viewer.ftl
@@ -515,5 +515,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/oc/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/oc/viewer.ftl
@@ -477,5 +477,5 @@ pdfjs-editor-undo-bar-message-multiple =
     }
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/pa-IN/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/pa-IN/viewer.ftl
@@ -517,5 +517,5 @@ pdfjs-editor-undo-bar-close-button-label = ਬੰਦ ਕਰੋ
 # Translations for ngx-extended-pdf-viewer additions only available in en-US
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/pl/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/pl/viewer.ftl
@@ -520,5 +520,5 @@ pdfjs-editor-undo-bar-close-button-label = Zamknij
 # Translations for ngx-extended-pdf-viewer additions only available in en-US
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/pt-BR/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/pt-BR/viewer.ftl
@@ -518,5 +518,5 @@ pdfjs-editor-undo-bar-close-button-label = Fechar
 unverified-signature-warning = Este arquivo PDF contém uma assinatura digital. O visualizador de PDF não pode verificar se a assinatura é válida. Faça download do arquivo e abra-o no Acrobat Reader para verificar se a assinatura é válida.
 # Translations for ngx-extended-pdf-viewer additions only available in en-US
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/pt-PT/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/pt-PT/viewer.ftl
@@ -518,5 +518,5 @@ pdfjs-editor-undo-bar-close-button-label = Fechar
 unverified-signature-warning = Este arquivo PDF contém uma assinatura digital. O visualizador de PDF não pode verificar se a assinatura é válida. Faça download do arquivo e abra-o no Acrobat Reader para verificar se a assinatura é válida.
 # Translations for ngx-extended-pdf-viewer additions only available in en-US
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/rm/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/rm/viewer.ftl
@@ -517,5 +517,5 @@ pdfjs-editor-undo-bar-close-button-label = Serrar
 # Translations for ngx-extended-pdf-viewer additions only available in en-US
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/ro/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/ro/viewer.ftl
@@ -438,5 +438,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/ru/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/ru/viewer.ftl
@@ -520,5 +520,5 @@ pdfjs-editor-undo-bar-close-button-label = Закрыть
 # Translations for ngx-extended-pdf-viewer additions only available in en-US
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/sat/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/sat/viewer.ftl
@@ -467,5 +467,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/sc/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/sc/viewer.ftl
@@ -462,5 +462,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/scn/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/scn/viewer.ftl
@@ -402,5 +402,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/sco/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/sco/viewer.ftl
@@ -440,5 +440,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/si/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/si/viewer.ftl
@@ -455,5 +455,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/sk/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/sk/viewer.ftl
@@ -523,5 +523,5 @@ pdfjs-editor-undo-bar-close-button-label = Zavrieť
 # Translations for ngx-extended-pdf-viewer additions only available in en-US
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/skr/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/skr/viewer.ftl
@@ -512,5 +512,5 @@ pdfjs-editor-undo-bar-message-multiple =
     }
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/sl/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/sl/viewer.ftl
@@ -524,5 +524,5 @@ pdfjs-editor-undo-bar-close-button-label = Zapri
 unverified-signature-warning = Dokument vsebuje digitalni podpis. PDF viewer ne more preveriti veljavnost podpisa. Prosimo prenesite dokument in veljavnost podpisa preverite v programu Acrobat Reader.
 # Translations for ngx-extended-pdf-viewer additions only available in en-US
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/son/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/son/viewer.ftl
@@ -432,5 +432,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/sq/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/sq/viewer.ftl
@@ -517,5 +517,5 @@ pdfjs-spread-even-button =
 pdfjs-spread-even-button-label = Even Spreads
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/sr/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/sr/viewer.ftl
@@ -485,5 +485,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/sv-SE/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/sv-SE/viewer.ftl
@@ -517,5 +517,5 @@ pdfjs-editor-undo-bar-close-button-label = Stäng
 # Translations for ngx-extended-pdf-viewer additions only available in en-US
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/szl/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/szl/viewer.ftl
@@ -438,5 +438,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/ta/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/ta/viewer.ftl
@@ -432,5 +432,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/te/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/te/viewer.ftl
@@ -432,5 +432,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/tg/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/tg/viewer.ftl
@@ -517,5 +517,5 @@ pdfjs-editor-undo-bar-close-button-label = Пӯшидан
 # Translations for ngx-extended-pdf-viewer additions only available in en-US
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/th/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/th/viewer.ftl
@@ -505,5 +505,5 @@ pdfjs-editor-undo-bar-close-button-label = ปิด
 # Translations for ngx-extended-pdf-viewer additions only available in en-US
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/tl/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/tl/viewer.ftl
@@ -438,5 +438,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/tr/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/tr/viewer.ftl
@@ -517,5 +517,5 @@ pdfjs-editor-undo-bar-close-button-label = Kapat
 # Translations for ngx-extended-pdf-viewer additions only available in en-US
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/trs/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/trs/viewer.ftl
@@ -419,5 +419,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/uk/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/uk/viewer.ftl
@@ -520,5 +520,5 @@ pdfjs-editor-undo-bar-close-button-label = Закрити
 # Translations for ngx-extended-pdf-viewer additions only available in en-US
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/ur/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/ur/viewer.ftl
@@ -436,5 +436,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/uz/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/uz/viewer.ftl
@@ -424,5 +424,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/vi/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/vi/viewer.ftl
@@ -505,5 +505,5 @@ pdfjs-editor-undo-bar-close-button-label = Đóng
 # Translations for ngx-extended-pdf-viewer additions only available in en-US
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/wo/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/wo/viewer.ftl
@@ -409,5 +409,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/xh/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/xh/viewer.ftl
@@ -432,5 +432,5 @@ pdfjs-editor-undo-bar-close-button =
 pdfjs-editor-undo-bar-close-button-label = Close
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/zh-CN/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/zh-CN/viewer.ftl
@@ -505,5 +505,5 @@ pdfjs-editor-undo-bar-close-button-label = 关闭
 # Translations for ngx-extended-pdf-viewer additions only available in en-US
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression

--- a/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/zh-TW/viewer.ftl
+++ b/projects/ngx-extended-pdf-viewer/bleeding-edge/locale/zh-TW/viewer.ftl
@@ -505,5 +505,5 @@ pdfjs-editor-undo-bar-close-button-label = 關閉
 # Translations for ngx-extended-pdf-viewer additions only available in en-US
 unverified-signature-warning = This PDF file contains a digital signature. The PDF viewer can't verify if the signature is valid. Please download the file and open it in Acrobat Reader to verify the signature is valid.
 pdfjs-infinite-scroll-button-label = Infinite scroll
-pdfjs-find-multiple-checkbox-label = match each word
+pdfjs-find-multiple-checkbox-label = Match Each Word
 pdfjs-find-regexp-checkbox-label = regular expression


### PR DESCRIPTION
Fixed capitalization of `match each word `checkbox label for consistency.

You can find this nuisance where the search component is enabled: https://pdfviewer.net/extended-pdf-viewer/simple
![image](https://github.com/user-attachments/assets/5ac65099-a134-4ad2-a574-47d2ddb4e4d6)
