### PR TITLE
 Bugfix: Hover color of buttons

### DIFF
--- a/projects/ngx-extended-pdf-viewer/src/lib/theme/common/ngx-extended-pdf-viewer.component.scss
+++ b/projects/ngx-extended-pdf-viewer/src/lib/theme/common/ngx-extended-pdf-viewer.component.scss
@@ -68,13 +68,31 @@ ngx-extended-pdf-viewer {
 }
 
 ngx-extended-pdf-viewer {
-
   button:focus,
   a:focus,
   input:focus,
   select:focus {
-    outline: none;
-    border: 1px solid blue;
+    outline: none !important;
+    border: 1px solid blue !important;
+  }
+
+  button:hover,
+  a:hover {
+    background-color: $general-button-hover !important;
+  }
+
+  .toolbar {
+    button:hover,
+    a:hover {
+      background-color: $toolbar-button-hover !important;
+    }
+  }
+
+  #sidebarContainer {
+    button:hover,
+    a:hover {
+      background-color: $toolbar-button-hover !important;
+    }
   }
 
   input[type="checkbox"]:focus {

--- a/projects/ngx-extended-pdf-viewer/src/lib/theme/pdf-dark-theme/colors.scss
+++ b/projects/ngx-extended-pdf-viewer/src/lib/theme/pdf-dark-theme/colors.scss
@@ -24,6 +24,10 @@ $toolbar-background: rgba(71, 71, 71, 1);
 
 $toolbar-border: $border;
 
+$toolbar-button-hover: #ffffff;
+
+$general-button-hover: #f0f0f0;
+
 $text-color: rgba(217, 217, 217, 1);
 
 $inputfield-text-color: #4d4d4d;

--- a/projects/ngx-extended-pdf-viewer/src/lib/theme/pdf-light-theme/colors.scss
+++ b/projects/ngx-extended-pdf-viewer/src/lib/theme/pdf-light-theme/colors.scss
@@ -24,6 +24,10 @@ $toolbar-background: #f9f9f9;
 
 $toolbar-border: #ddd;
 
+$toolbar-button-hover: #ffffff;
+
+$general-button-hover: #f0f0f0;
+
 $text-color: #5a5a5a;
 
 $inputfield-text-color: #5a5a5a;


### PR DESCRIPTION
- To fix an accessibility issue, I added hover color for all buttons under the `ngx-extended-pdf-viewer` tag.
- Updated the `:focus` style to use `!important`.
- Added 2 new colors to the light and dark themes for toolbar and general button hover colors.

This screen recording shows the before on the showcase app and the after on my local:

https://github.com/user-attachments/assets/80894ef3-9aa0-4474-a622-17b25264fcfe