### PR TITLE
stephanrauh/ngx-extended-pdf-viewer#3242 fixed the findbar's showFind…

### DIFF
--- a/projects/ngx-extended-pdf-viewer/src/lib/sidebar/pdf-sidebar/pdf-sidebar-toolbar/pdf-sidebar-toolbar.component.html
+++ b/projects/ngx-extended-pdf-viewer/src/lib/sidebar/pdf-sidebar/pdf-sidebar-toolbar/pdf-sidebar-toolbar.component.html
@@ -1,4 +1,4 @@
-<div id="toolbarSidebar" [style.height]="height">
+<div id="toolbarSidebar" [style.height]="height()">
   <div id="toolbarSidebarLeft">
     <button
       aria-label="Thumbnails"
@@ -7,7 +7,7 @@
       class="toolbarButton"
       title="Show Thumbnails"
       data-l10n-id="pdfjs-thumbs-button"
-      [style.zoom]="mobileFriendlyZoomScale"
+      [style.zoom]="mobileFriendlyZoomScale()"
     >
       <span data-l10n-id="pdfjs-thumbs-button-label">Thumbnails</span>
       <svg aria-hidden="true" focusable="false" width="20px" height="20px" viewBox="0 0 24 24">
@@ -25,7 +25,7 @@
       title="Show Document Outline (double-click to expand/collapse all items)"
       data-l10n-id="pdfjs-document-outline-button"
       hidden="true"
-      [style.zoom]="mobileFriendlyZoomScale"
+      [style.zoom]="mobileFriendlyZoomScale()"
       aria-label="Show Document Outline (double-click to expand/collapse all items)"
     >
       <span data-l10n-id="pdfjs-document-outline-button-label">Document Outline</span>
@@ -41,7 +41,7 @@
       title="Show Attachments"
       data-l10n-id="pdfjs-attachments-button"
       hidden="true"
-      [style.zoom]="mobileFriendlyZoomScale"
+      [style.zoom]="mobileFriendlyZoomScale()"
     >
       <span data-l10n-id="pdfjs-attachments-button-label">Attachments</span>
       <svg aria-hidden="true" focusable="false" width="20px" height="20px" viewBox="0 0 24 24">
@@ -58,7 +58,7 @@
       title="Show Layers (double-click to reset all layers to the default state)"
       data-l10n-id="pdfjs-layers-button"
       hidden="true"
-      [style.zoom]="mobileFriendlyZoomScale"
+      [style.zoom]="mobileFriendlyZoomScale()"
       aria-label="Show Layers (double-click to reset all layers to the default state)"
     >
       <span data-l10n-id="pdfjs-layers-button-label">Layers</span>
@@ -88,7 +88,7 @@
         disabled="disabled"
         title="Find Current Outline Item"
         data-l10n-id="pdfjs-current-outline-item-button"
-        [style.zoom]="mobileFriendlyZoomScale"
+        [style.zoom]="mobileFriendlyZoomScale()"
         aria-label="Find Current Outline Item"
       >
         <span data-l10n-id="pdfjs-current-outline-item-button-label">Current Outline Item</span>

--- a/projects/ngx-extended-pdf-viewer/src/lib/sidebar/pdf-sidebar/pdf-sidebar-toolbar/pdf-sidebar-toolbar.component.spec.ts
+++ b/projects/ngx-extended-pdf-viewer/src/lib/sidebar/pdf-sidebar/pdf-sidebar-toolbar/pdf-sidebar-toolbar.component.spec.ts
@@ -1,0 +1,46 @@
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { PdfSidebarToolbarComponent } from './pdf-sidebar-toolbar.component';
+
+describe('PdfSidebarToolbarComponent', () => {
+  let component: PdfSidebarToolbarComponent;
+  let fixture: ComponentFixture<PdfSidebarToolbarComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [PdfSidebarToolbarComponent],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PdfSidebarToolbarComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeInstanceOf(PdfSidebarToolbarComponent);
+  });
+
+  it('should default mobileFriendlyZoomScale to 1', () => {
+    expect(component.mobileFriendlyZoomScale()).toBe(1);
+    expect(component.height()).toBe('32px');
+  });
+
+  describe('mobileFriendlyZoomScale', () => {
+    it('should scale the height of the toolbar', () => {
+      fixture.componentRef.setInput('mobileFriendlyZoomScale', 2);
+      fixture.detectChanges();
+      const toolbar = fixture.nativeElement.querySelector('#toolbarSidebar') as HTMLElement;
+      expect(toolbar.style.height).toBe('64px');
+    });
+
+    it('should zoom every toolbar button', () => {
+      fixture.componentRef.setInput('mobileFriendlyZoomScale', 1.5);
+      fixture.detectChanges();
+      const buttons = fixture.nativeElement.querySelectorAll('button.toolbarButton') as NodeListOf<HTMLElement>;
+      expect(buttons.length).toBeGreaterThan(0);
+      // jsdom hands back `zoom` unstringified, so compare the printed value
+      buttons.forEach((button) => expect(`${button.style.zoom}`).toBe('1.5'));
+    });
+  });
+});

--- a/projects/ngx-extended-pdf-viewer/src/lib/toolbar/pdf-findbar/pdf-findbar.component.html
+++ b/projects/ngx-extended-pdf-viewer/src/lib/toolbar/pdf-findbar/pdf-findbar.component.html
@@ -12,22 +12,22 @@
   <pdf-find-input-area [customFindbarInputArea]="customFindbarInputArea()"></pdf-find-input-area>
 
   <div id="findbarOptionsOneContainer" class="toolbarHorizontalGroup">
-    <pdf-find-highlight-all [class.hidden]="!showFindHighlightAll"></pdf-find-highlight-all>
-    <pdf-find-match-case [class.hidden]="!showFindMatchCase"></pdf-find-match-case>
+    <pdf-find-highlight-all [class.hidden]="!showFindHighlightAll()"></pdf-find-highlight-all>
+    <pdf-find-match-case [class.hidden]="!showFindMatchCase()"></pdf-find-match-case>
   </div>
 
   <div id="findbarOptionsTwoContainer" class="toolbarHorizontalGroup">
-    <pdf-match-diacritics [class.hidden]="!showFindMatchDiacritics"></pdf-match-diacritics>
-    <pdf-find-entire-word [class.hidden]="!showFindEntireWord"></pdf-find-entire-word>
+    <pdf-match-diacritics [class.hidden]="!showFindMatchDiacritics()"></pdf-match-diacritics>
+    <pdf-find-entire-word [class.hidden]="!showFindEntireWord()"></pdf-find-entire-word>
   </div>
 
-  <div id="findbarOptionsThreeContainer" class="toolbarHorizontalGroup" [class.hidden]="!showFindMultiple && !showFindRegexp">
-    <pdf-find-multiple [class.hidden]="!showFindMultiple"></pdf-find-multiple>
-    <pdf-find-regexp [class.hidden]="!showFindRegexp"></pdf-find-regexp>
+  <div id="findbarOptionsThreeContainer" class="toolbarHorizontalGroup" [class.hidden]="!showFindMultiple() && !showFindRegexp()">
+    <pdf-find-multiple [class.hidden]="!showFindMultiple()"></pdf-find-multiple>
+    <pdf-find-regexp [class.hidden]="!showFindRegexp()"></pdf-find-regexp>
   </div>
 
   <div id="findbarMessageContainer" class="toolbarHorizontalGroup" aria-live="polite">
-    <pdf-find-results-count [class.hidden]="!showFindResultsCount"></pdf-find-results-count>
-    <pdf-findbar-message-container [class.hidden]="!showFindMessages"></pdf-findbar-message-container>
+    <pdf-find-results-count [class.hidden]="!showFindResultsCount()"></pdf-find-results-count>
+    <pdf-findbar-message-container [class.hidden]="!showFindMessages()"></pdf-findbar-message-container>
   </div>
 </ng-template>

--- a/projects/ngx-extended-pdf-viewer/src/lib/toolbar/pdf-findbar/pdf-findbar.component.spec.ts
+++ b/projects/ngx-extended-pdf-viewer/src/lib/toolbar/pdf-findbar/pdf-findbar.component.spec.ts
@@ -1,0 +1,77 @@
+import { CommonModule } from '@angular/common';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { PdfFindbarComponent } from './pdf-findbar.component';
+
+describe('PdfFindbarComponent', () => {
+  let component: PdfFindbarComponent;
+  let fixture: ComponentFixture<PdfFindbarComponent>;
+
+  const isHidden = (selector: string): boolean => {
+    const element = fixture.nativeElement.querySelector(selector) as HTMLElement | null;
+    if (!element) {
+      throw new Error(`the findbar template doesn't contain ${selector}`);
+    }
+    return element.classList.contains('hidden');
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [PdfFindbarComponent],
+      imports: [CommonModule],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PdfFindbarComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('mobileFriendlyZoomScale', 1);
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeInstanceOf(PdfFindbarComponent);
+  });
+
+  describe('showFind* inputs', () => {
+    const options: Array<{ input: string; selector: string }> = [
+      { input: 'showFindHighlightAll', selector: 'pdf-find-highlight-all' },
+      { input: 'showFindMatchCase', selector: 'pdf-find-match-case' },
+      { input: 'showFindMatchDiacritics', selector: 'pdf-match-diacritics' },
+      { input: 'showFindEntireWord', selector: 'pdf-find-entire-word' },
+      { input: 'showFindMultiple', selector: 'pdf-find-multiple' },
+      { input: 'showFindRegexp', selector: 'pdf-find-regexp' },
+      { input: 'showFindResultsCount', selector: 'pdf-find-results-count' },
+      { input: 'showFindMessages', selector: 'pdf-findbar-message-container' },
+    ];
+
+    options.forEach(({ input, selector }) => {
+      it(`should hide ${selector} when ${input} is false`, () => {
+        fixture.componentRef.setInput(input, false);
+        fixture.detectChanges();
+        expect(isHidden(selector)).toBe(true);
+      });
+
+      it(`should show ${selector} again when ${input} flips back to true`, () => {
+        fixture.componentRef.setInput(input, false);
+        fixture.detectChanges();
+        fixture.componentRef.setInput(input, true);
+        fixture.detectChanges();
+        expect(isHidden(selector)).toBe(false);
+      });
+    });
+
+    it('should hide the third option group when neither multiple nor regexp is shown', () => {
+      fixture.componentRef.setInput('showFindMultiple', false);
+      fixture.componentRef.setInput('showFindRegexp', false);
+      fixture.detectChanges();
+      expect(isHidden('#findbarOptionsThreeContainer')).toBe(true);
+    });
+
+    it('should keep the third option group visible if one of its options is shown', () => {
+      fixture.componentRef.setInput('showFindMultiple', false);
+      fixture.componentRef.setInput('showFindRegexp', true);
+      fixture.detectChanges();
+      expect(isHidden('#findbarOptionsThreeContainer')).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
…* options and the sidebar toolbar's zoom - both templates tested their signal inputs without calling them

A signal is a function object, so the expressions were always truthy and the bindings never took effect: every [showFind*] option stayed visible - most visibly the regex search, which defaults to off - and the sidebar toolbar never scaled with [mobileFriendlyZoom].